### PR TITLE
Add option to run unidentified esmini version

### DIFF
--- a/Scenarios/run_Scenario.bat
+++ b/Scenarios/run_Scenario.bat
@@ -56,9 +56,13 @@ IF !Major! EQU 2 (
 )
 
 IF !supported! EQU 0 (
-    ECHO Unsupported esmini version.
+    ECHO Unsupported or unidentified esmini version.
+    SET /p sel2="Continue anyway? [y/n] (n): "
+    IF !sel2!==y GOTO esmini_continue
     GOTO finish
 )
+
+:esmini_continue 
 
 SET x=0
 FOR /f "delims=" %%a in ('dir /s /b *.xosc') DO (


### PR DESCRIPTION
Local builds of esmini does not get a complete version stamp (since it may contain local modifications).
In order to smoothly support custom esmini builds we propose this change to allow for running the scenarios in spite esmini version could not be identified. The user is still informed of that the esmini version is not identified or not supported, but is given an option to continue anyway. Default option is to quit.